### PR TITLE
Add prototypical/WIP intermediate + type checker

### DIFF
--- a/examples/extern.lri
+++ b/examples/extern.lri
@@ -1,3 +1,6 @@
 extern fn print(arg: String);
 
-fn main() {}
+fn main() {
+    print("Hello extern functions!");
+    // print(false);
+}

--- a/examples/type_error.lri
+++ b/examples/type_error.lri
@@ -1,0 +1,7 @@
+fn main() {
+    f("hi world");
+}
+
+fn f(x: i64) {
+    print(x);
+}

--- a/laria/src/main.rs
+++ b/laria/src/main.rs
@@ -1,4 +1,4 @@
-use laria_backend::{lex_and_parse, lower_to_vm, unstable_features::compiler::UnstableFeatures};
+use laria_backend::{compile_for_vm, unstable_features::compiler::UnstableFeatures};
 use laria_log::*;
 use laria_vm::vm::VM;
 use pico_args::Arguments;
@@ -116,22 +116,14 @@ fn main() {
             info!("compiling {}...", source_file)
         }
 
-        let ast = lex_and_parse(source_path);
-
-        if args.verbose {
-            debug!("ast:\n{:#?}", ast);
-        } else {
-            debug!("ast:\n{}", ast);
-        }
-
-        todo!("lower to file");
+        //let ast = compile_for_vm(source_path);
+        todo!("parse, compile, validate, lower to file");
     } else {
         if args.verbose {
             info!("interpreting {}...", source_file);
         }
 
-        let ast = lex_and_parse(source_path);
-        let script = lower_to_vm::lower_script(ast);
+        let script = compile_for_vm(source_path);
         let mut vm = VM::new(script, args.trace_execution);
 
         loop {

--- a/laria/src/main.rs
+++ b/laria/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
             info!("interpreting {}...", source_file);
         }
 
-        let script = compile_for_vm(source_path);
+        let script = compile_for_vm(source_path, args.unstable_features);
         let mut vm = VM::new(script, args.trace_execution);
 
         loop {

--- a/laria_backend/src/hir/hir_tree.rs
+++ b/laria_backend/src/hir/hir_tree.rs
@@ -1,0 +1,255 @@
+use super::types::{Type, TypeEnvironment, TypeId};
+use crate::{ast, errors::Span, lexer::token::LiteralKind};
+
+#[derive(Clone, Debug)]
+pub(super) struct Script {
+    pub(super) functions: Vec<FunctionDef>,
+    // `extern fn`s will be added to the type environment when lowering
+    pub(super) span: Span,
+}
+
+impl Script {
+    pub(super) fn new(functions: Vec<FunctionDef>, span: Span) -> Self {
+        Self { functions, span }
+    }
+}
+
+/// A function declaration. This is just the function's header,
+/// which contains its name and arguments.
+#[derive(Clone, Debug)]
+pub(super) struct FunctionDecl {
+    pub(super) name: String,
+    pub(super) arg_names: Vec<String>,
+    /// This should be a [`Tuple`] containing the argument types.
+    ///
+    /// [`Tuple`]: Type::Tuple
+    pub(super) args_type: TypeId,
+    pub(super) ret_type: TypeId,
+    /// Type of the whole function.
+    /// This should be a [`Function`] of the form
+    /// `args_type -> ret_type`.
+    ///
+    /// [`Function`]: Type::Function
+    pub(super) fn_type: TypeId,
+    pub(super) span: Span,
+}
+
+impl FunctionDecl {
+    pub(super) fn new(
+        ty_env: &mut TypeEnvironment,
+        name: String,
+        arg_names: Vec<String>,
+        args_type: TypeId,
+        ret_type: TypeId,
+        span: Span,
+    ) -> Self {
+        let fn_type = ty_env.get_or_add_type(Type::Function(args_type, ret_type));
+
+        Self {
+            name,
+            arg_names,
+            args_type,
+            ret_type,
+            fn_type,
+            span,
+        }
+    }
+}
+
+/// A function definition, consisting of a [`FunctionDecl`]
+/// followed by a block.
+#[derive(Clone, Debug)]
+pub(super) struct FunctionDef {
+    pub(super) header: FunctionDecl,
+    pub(super) body: Block,
+    pub(super) span: Span,
+}
+
+impl FunctionDef {
+    pub(super) const fn new(header: FunctionDecl, body: Block, span: Span) -> Self {
+        Self { header, body, span }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct ExternFn {
+    pub(super) header: FunctionDecl,
+    pub(super) span: Span,
+}
+
+impl ExternFn {
+    pub(super) fn new(header: FunctionDecl, span: Span) -> Self {
+        Self { header, span }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Block {
+    pub(super) statements: Vec<Statement>,
+    pub(super) return_expr: Option<Box<Expression>>,
+    pub(super) type_id: TypeId,
+    pub(super) span: Span,
+}
+
+impl Block {
+    pub(super) const fn new(
+        statements: Vec<Statement>,
+        return_expr: Option<Box<Expression>>,
+        type_id: TypeId,
+        span: Span,
+    ) -> Self {
+        Self {
+            statements,
+            return_expr,
+            type_id,
+            span,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum StatementKind {
+    /// An expression followed by a semicolon,
+    /// ex. `2 + 2;`, or a block-like expression,
+    /// ex. `loop {}`.
+    Expression(Expression),
+
+    // TODO: pattern matching?
+    /// A variable declaration,
+    /// `let lhs.0: lhs.1 = rhs;`.
+    Declaration((String, TypeId), Expression),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Statement {
+    pub(super) kind: StatementKind,
+    pub(super) span: Span,
+}
+
+impl Statement {
+    pub(super) const fn new(kind: StatementKind, span: Span) -> Self {
+        Self { kind, span }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum UnaryOperator {
+    Negative,
+    Not,
+}
+
+impl From<ast::UnaryOperator> for UnaryOperator {
+    fn from(ast_op: ast::UnaryOperator) -> Self {
+        match ast_op {
+            ast::UnaryOperator::Negative => Self::Negative,
+            ast::UnaryOperator::Not => Self::Not,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub(super) enum BinaryOperator {
+    Add,
+    Multiply,
+    Subtract,
+    Divide,
+    Equal,
+    NotEqual,
+    GreaterThan,
+    LessThan,
+    GreaterThanEqual,
+    LessThanEqual,
+    BoolAnd,
+    BoolOr,
+    BitAnd,
+    BitOr,
+    BitXor,
+    Modulo,
+    ShiftLeft,
+    ShiftRight,
+    Assign,
+    As,
+}
+
+impl From<ast::BinaryOperator> for BinaryOperator {
+    fn from(ast_op: ast::BinaryOperator) -> Self {
+        match ast_op {
+            ast::BinaryOperator::Add => Self::Add,
+            ast::BinaryOperator::Multiply => Self::Multiply,
+            ast::BinaryOperator::Subtract => Self::Subtract,
+            ast::BinaryOperator::Divide => Self::Divide,
+            ast::BinaryOperator::Equal => Self::Equal,
+            ast::BinaryOperator::NotEqual => Self::NotEqual,
+            ast::BinaryOperator::GreaterThan => Self::GreaterThan,
+            ast::BinaryOperator::LessThan => Self::LessThan,
+            ast::BinaryOperator::GreaterThanEqual => Self::GreaterThanEqual,
+            ast::BinaryOperator::LessThanEqual => Self::LessThanEqual,
+            ast::BinaryOperator::BoolAnd => Self::BoolAnd,
+            ast::BinaryOperator::BoolOr => Self::BoolOr,
+            ast::BinaryOperator::BitAnd => Self::BitAnd,
+            ast::BinaryOperator::BitOr => Self::BitOr,
+            ast::BinaryOperator::BitXor => Self::BitXor,
+            ast::BinaryOperator::Modulo => Self::Modulo,
+            ast::BinaryOperator::ShiftLeft => Self::ShiftLeft,
+            ast::BinaryOperator::ShiftRight => Self::ShiftRight,
+            ast::BinaryOperator::Assign => Self::Assign,
+            ast::BinaryOperator::As => Self::As,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum ExpressionKind {
+    /// An if expression,
+    /// `if expr { ... } else { ... }`.
+    /// The second block represents the optional `else` portion.
+    If {
+        cond: Box<Expression>,
+        then: (Block, TypeId),
+        otherwise: Option<(Block, TypeId)>,
+    },
+
+    /// A loop expression, `loop x {}`.
+    /// If the expression is `None`, this is an infinite loop.
+    /// Otherwise, this loops x times, where x is the value
+    /// of the expression and the expression is of type {integer}.
+    Loop(Option<Box<Expression>>, Block),
+
+    /// A while expression, `while expr { ... }`.
+    While(Box<Expression>, Block),
+
+    /// A block, `{ ... }`.
+    Block(Block),
+
+    /// A binary operation, ex. `x + y`.
+    BinaryOperation(Box<Expression>, BinaryOperator, Box<Expression>),
+
+    /// A unary operation, ex. `-x`.
+    UnaryOperation(UnaryOperator, Box<Expression>),
+
+    /// A function call, ex. `factorial(4)`.
+    FnCall(Box<Expression>, Vec<Expression>),
+
+    /// A literal, such as `4` or `"Hello"`.
+    Literal(LiteralKind),
+
+    /// An identifier, ex. `foo`.
+    Identifier(String),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) struct Expression {
+    pub(super) kind: ExpressionKind,
+    pub(super) type_id: TypeId,
+    pub(super) span: Span,
+}
+
+impl Expression {
+    pub(super) const fn new(kind: ExpressionKind, type_id: TypeId, span: Span) -> Self {
+        Self {
+            kind,
+            type_id,
+            span,
+        }
+    }
+}

--- a/laria_backend/src/hir/lower.rs
+++ b/laria_backend/src/hir/lower.rs
@@ -1,0 +1,222 @@
+use super::{
+    hir_tree,
+    types::{Type, TypeEnvironment, TypeId},
+};
+use crate::ast;
+
+/// Helper struct to hold state while lowering the AST.
+struct LowerAst<'src> {
+    ty_env: TypeEnvironment<'src>,
+}
+
+impl<'src> LowerAst<'src> {
+    fn new(source: &'src str) -> Self {
+        Self {
+            ty_env: TypeEnvironment::new(source),
+        }
+    }
+
+    fn lower(mut self, ast_script: ast::Script) -> (hir_tree::Script, TypeEnvironment<'src>) {
+        let mut functions = Vec::new();
+
+        for function in ast_script.functions {
+            functions.push(self.lower_function(function));
+        }
+
+        for extern_fn in ast_script.extern_fns {
+            self.lower_fn_header(extern_fn.header);
+        }
+
+        let script = hir_tree::Script::new(functions, ast_script.span);
+        (script, self.ty_env)
+    }
+
+    fn lower_function(&mut self, function: ast::FunctionDef) -> hir_tree::FunctionDef {
+        let header = self.lower_fn_header(function.header);
+        let body = self.lower_block(function.body);
+        hir_tree::FunctionDef::new(header, body, function.span)
+    }
+
+    // TODO: use path lookup to do this correctly
+    /// Temporary hack to add a type to the environment by name.
+    fn add_type_by_name(&mut self, name: String) -> TypeId {
+        match name.as_str() {
+            "i32" | "i64" => self.ty_env.get_or_add_type(Type::Integer),
+            "bool" => self.ty_env.get_or_add_type(Type::Boolean),
+            "f32" | "f64" => self.ty_env.get_or_add_type(Type::Float),
+            "String" => self.ty_env.get_or_add_type(Type::String),
+            "()" => self.ty_env.get_or_add_type(Type::unit()),
+            _ => todo!("unknown type `{}`", name),
+        }
+    }
+
+    fn lower_fn_header(&mut self, header: ast::FunctionDecl) -> hir_tree::FunctionDecl {
+        let mut arg_names = Vec::new();
+        let mut arg_types = Vec::new();
+
+        for (arg_name, arg_type) in header.arguments {
+            arg_names.push(arg_name);
+            arg_types.push(self.add_type_by_name(arg_type));
+        }
+
+        let args_list_type = self.ty_env.get_or_add_type(Type::Tuple(arg_types));
+        // TODO: fix when paths are added
+        let return_type = self.add_type_by_name(header.return_type.unwrap_or("()".to_owned()));
+        let fn_type = self
+            .ty_env
+            .get_or_add_type(Type::Function(args_list_type, return_type));
+
+        let type_id_for_fn_name = self.ty_env.get_type_id_for_ident(&header.name);
+        // Should be infallible since a variable should've just been created
+        // (nb. will only be true when paths are added)
+        self.ty_env
+            .unify(type_id_for_fn_name, fn_type, header.span)
+            .expect(&format!(
+                "Encountered type bug while lowering {}",
+                header.name
+            ));
+
+        hir_tree::FunctionDecl::new(
+            &mut self.ty_env,
+            header.name,
+            arg_names,
+            args_list_type,
+            return_type,
+            header.span,
+        )
+    }
+
+    fn lower_block(&mut self, block: ast::Block) -> hir_tree::Block {
+        let mut statements = Vec::new();
+
+        for statement in block.contents {
+            statements.push(self.lower_statement(statement));
+        }
+
+        let return_expr = match block.return_expr {
+            Some(expr) => Some(Box::new(self.lower_expression(*expr))),
+            None => None,
+        };
+
+        hir_tree::Block::new(
+            statements,
+            return_expr,
+            self.ty_env.add_new_type_variable(),
+            block.span,
+        )
+    }
+
+    fn lower_statement(&mut self, statement: ast::Statement) -> hir_tree::Statement {
+        match statement.kind {
+            ast::StatementKind::Expression(expr) => {
+                let kind = hir_tree::StatementKind::Expression(self.lower_expression(expr));
+                hir_tree::Statement::new(kind, statement.span)
+            },
+
+            ast::StatementKind::Declaration((name, maybe_type), expr) => {
+                let rhs = self.lower_expression(expr);
+
+                let ty = match maybe_type {
+                    Some(given_type_name) => self.add_type_by_name(given_type_name),
+                    None => self.ty_env.add_new_type_variable(),
+                };
+
+                let kind = hir_tree::StatementKind::Declaration((name, ty), rhs);
+                hir_tree::Statement::new(kind, statement.span)
+            },
+        }
+    }
+
+    fn lower_expression(&mut self, expression: ast::Expression) -> hir_tree::Expression {
+        let kind = match expression.kind {
+            ast::ExpressionKind::If {
+                cond,
+                then,
+                otherwise,
+            } => {
+                let cond = Box::new(self.lower_expression(*cond));
+
+                let then = {
+                    let block = self.lower_block(then);
+                    let ty = block.type_id;
+                    (block, ty)
+                };
+
+                let otherwise = otherwise.map(|block| {
+                    let block = self.lower_block(block);
+                    let ty = block.type_id;
+                    (block, ty)
+                });
+
+                let kind = hir_tree::ExpressionKind::If {
+                    cond,
+                    then,
+                    otherwise,
+                };
+
+                kind
+            },
+
+            ast::ExpressionKind::Loop(maybe_count, body) => {
+                let maybe_count = match maybe_count {
+                    Some(count) => Some(Box::new(self.lower_expression(*count))),
+                    None => None,
+                };
+
+                let body = self.lower_block(body);
+                hir_tree::ExpressionKind::Loop(maybe_count, body)
+            },
+
+            ast::ExpressionKind::While(cond, body) => {
+                let cond = Box::new(self.lower_expression(*cond));
+                let body = self.lower_block(body);
+                hir_tree::ExpressionKind::While(cond, body)
+            },
+
+            ast::ExpressionKind::Block(block) => {
+                hir_tree::ExpressionKind::Block(self.lower_block(block))
+            },
+
+            ast::ExpressionKind::BinaryOperation(lhs, op, rhs) => {
+                let lhs = Box::new(self.lower_expression(*lhs));
+                let rhs = Box::new(self.lower_expression(*rhs));
+                hir_tree::ExpressionKind::BinaryOperation(lhs, op.into(), rhs)
+            },
+
+            ast::ExpressionKind::UnaryOperation(op, expr) => {
+                let expr = Box::new(self.lower_expression(*expr));
+                hir_tree::ExpressionKind::UnaryOperation(op.into(), expr)
+            },
+
+            ast::ExpressionKind::FnCall(func, args) => {
+                let func = Box::new(self.lower_expression(*func));
+                let args = args
+                    .into_iter()
+                    .map(|arg| self.lower_expression(arg))
+                    .collect();
+
+                hir_tree::ExpressionKind::FnCall(func, args)
+            },
+
+            ast::ExpressionKind::PartialApp(_, _) => todo!("partial app"),
+            ast::ExpressionKind::Literal(literal) => hir_tree::ExpressionKind::Literal(literal),
+            ast::ExpressionKind::Identifier(ident) => hir_tree::ExpressionKind::Identifier(ident),
+            ast::ExpressionKind::Empty => todo!("get rid of empty?"),
+        };
+
+        let expr_type = self.ty_env.add_new_type_variable();
+        hir_tree::Expression::new(kind, expr_type, expression.span)
+    }
+}
+
+/// Lowers an AST to IR, creating a type environment in
+/// the process. Returns the root of the IR tree (a [`Script`])
+/// and the new type environment.
+///
+/// [`Script`]: hir_tree::Script
+pub(super) fn lower_ast<'src>(
+    ast: ast::Script,
+    source: &'src str,
+) -> (hir_tree::Script, TypeEnvironment<'src>) {
+    LowerAst::new(source).lower(ast)
+}

--- a/laria_backend/src/hir/mod.rs
+++ b/laria_backend/src/hir/mod.rs
@@ -1,0 +1,27 @@
+//! HIR is the High-level Intermediate Representation, inspired by
+//! [Rust's HIR][rust-hir]. While very similar to [the AST][ast], it is
+//! different in a couple of key aspects:
+//!
+//! * Some constructs, such as partial applications, are desugared to make them
+//!   easier for the compiler to work with.
+//! * HIR has type information and is used for typechecking scripts.
+//!
+//! Please note that the HIR is currently a work in progress. There are
+//! a few hacks here and there that will be cleaned up soon, namely
+//! the use of raw identifiers rather than unique paths, which can
+//! confuse analysis passes when dealing with complex (or even simple)
+//! scripts.
+//!
+//! [rust-hir]: https://rustc-dev-guide.rust-lang.org/hir.html
+
+use crate::parser::ast;
+
+mod hir_tree;
+mod lower;
+mod typecheck;
+mod types;
+
+pub(crate) fn validate(ast: ast::Script, source: &str) {
+    let (mut ir, ty_env) = lower::lower_ast(ast, source);
+    typecheck::typecheck(ir, ty_env, source);
+}

--- a/laria_backend/src/hir/typecheck.rs
+++ b/laria_backend/src/hir/typecheck.rs
@@ -1,0 +1,266 @@
+use super::{
+    hir_tree::{
+        BinaryOperator, Block, Expression, ExpressionKind, FunctionDef, Script, Statement,
+        StatementKind, UnaryOperator,
+    },
+    types::{Type, TypeEnvironment, TypeId},
+};
+use crate::{
+    errors::{DiagnosticsContext, Span},
+    lexer::token::LiteralKind,
+};
+
+struct Typecheck<'src> {
+    ty_env: TypeEnvironment<'src>,
+    error_ctx: DiagnosticsContext<'src>,
+    failed: bool,
+}
+
+impl<'src> Typecheck<'src> {
+    fn new(ty_env: TypeEnvironment<'src>, source: &'src str) -> Self {
+        Self {
+            ty_env,
+            error_ctx: DiagnosticsContext::new(source, None),
+            failed: false,
+        }
+    }
+
+    fn check_script(mut self, mut script: Script) -> (Script, TypeEnvironment<'src>) {
+        for function in &mut script.functions {
+            self.check_function(function);
+        }
+
+        if self.failed {
+            todo!("typecheck failed")
+        }
+
+        (script, self.ty_env)
+    }
+
+    fn try_unify(&mut self, first_id: TypeId, second_id: TypeId, span: Span) {
+        if let Err(_) = self.ty_env.unify(first_id, second_id, span) {
+            self.failed = true;
+        }
+    }
+
+    fn check_function(&mut self, function: &mut FunctionDef) {
+        // The type environment should've been filled with the
+        // arguments' idents by the lowering process
+        self.check_block(&function.body);
+        self.try_unify(
+            function.body.type_id,
+            function.header.ret_type,
+            function.body.span,
+        );
+    }
+
+    /// Returns the TypeId corresponding to the block's return type.
+    fn check_block(&mut self, block: &Block) -> TypeId {
+        for stmt in &block.statements {
+            self.check_statement(stmt);
+        }
+
+        if let Some(return_expr) = &block.return_expr {
+            self.check_expression(return_expr.as_ref());
+            self.try_unify(block.type_id, return_expr.type_id, return_expr.span);
+        }
+
+        block.type_id
+    }
+
+    fn check_statement(&mut self, stmt: &Statement) {
+        match stmt.kind {
+            StatementKind::Expression(ref expr) => {
+                self.check_expression(expr);
+            },
+
+            StatementKind::Declaration((ref ident, type_id), ref expr) => {
+                // Typecheck the right hand side
+                let expr_id = self.check_expression(expr);
+                // Unify that with the ascribed type, if any
+                self.try_unify(type_id, expr_id, expr.span);
+                // Get the type associated with the identifier
+                let ident_ty = self.ty_env.get_type_id_for_ident(ident);
+                // ...and unify that with the ascribed type
+                self.try_unify(ident_ty, type_id, expr.span);
+            },
+        }
+    }
+
+    /// Returns the TypeId corresponding to the expression's return type.
+    fn check_expression(&mut self, expr: &Expression) -> TypeId {
+        let res = match expr.kind {
+            ExpressionKind::If {
+                ref cond,
+                ref then,
+                ref otherwise,
+            } => {
+                self.check_expression(cond);
+                let bool_id = self.ty_env.get_or_add_type(Type::Boolean);
+                self.try_unify(cond.type_id, bool_id, cond.span);
+
+                let then_ret_ty_id = self.check_block(&then.0);
+                self.try_unify(then.1, then_ret_ty_id, then.0.span);
+
+                if let Some(otherwise) = otherwise {
+                    let else_ret_ty_id = self.check_block(&otherwise.0);
+                    self.try_unify(otherwise.1, else_ret_ty_id, otherwise.0.span);
+
+                    // The return types of both blocks must be the same.
+                    self.try_unify(otherwise.1, then.1, otherwise.0.span);
+                }
+
+                then.1
+            },
+
+            ExpressionKind::Loop(ref maybe_count, ref body) => {
+                if let Some(count) = maybe_count {
+                    let int_ty = self.ty_env.get_or_add_type(Type::Integer);
+                    self.try_unify(count.type_id, int_ty, count.span);
+                }
+
+                self.check_block(body);
+                body.type_id
+            },
+
+            ExpressionKind::While(ref cond, ref body) => {
+                let bool_ty = self.ty_env.get_or_add_type(Type::Boolean);
+                self.try_unify(cond.type_id, bool_ty, cond.span);
+                self.check_block(body);
+                self.ty_env.get_or_add_type(Type::unit())
+            },
+
+            ExpressionKind::Block(ref block) => {
+                self.check_block(block);
+                block.type_id
+            },
+
+            ExpressionKind::BinaryOperation(ref lhs, op, ref rhs) => {
+                // TODO: this should probably do something with traits
+                // TODO: check float + float, int + int
+                self.check_expression(lhs);
+                self.check_expression(rhs);
+                self.try_unify(lhs.type_id, rhs.type_id, rhs.span);
+
+                match op {
+                    BinaryOperator::Add
+                    | BinaryOperator::Subtract
+                    | BinaryOperator::Multiply
+                    | BinaryOperator::Divide
+                    | BinaryOperator::Modulo => lhs.type_id,
+
+                    BinaryOperator::Equal
+                    | BinaryOperator::NotEqual
+                    | BinaryOperator::GreaterThan
+                    | BinaryOperator::LessThan
+                    | BinaryOperator::GreaterThanEqual
+                    | BinaryOperator::LessThanEqual => self.ty_env.get_or_add_type(Type::Boolean),
+
+                    BinaryOperator::BoolAnd | BinaryOperator::BoolOr => {
+                        let bool_type = self.ty_env.get_or_add_type(Type::Boolean);
+                        self.try_unify(lhs.type_id, bool_type, lhs.span);
+                        self.try_unify(rhs.type_id, bool_type, rhs.span);
+                        bool_type
+                    },
+
+                    BinaryOperator::BitAnd
+                    | BinaryOperator::BitOr
+                    | BinaryOperator::BitXor
+                    | BinaryOperator::ShiftLeft
+                    | BinaryOperator::ShiftRight => {
+                        let int_type = self.ty_env.get_or_add_type(Type::Integer);
+                        self.try_unify(lhs.type_id, int_type, lhs.span);
+                        self.try_unify(rhs.type_id, int_type, rhs.span);
+                        int_type
+                    },
+
+                    BinaryOperator::Assign => lhs.type_id,
+
+                    BinaryOperator::As => todo!(),
+                }
+            },
+
+            ExpressionKind::UnaryOperation(op, ref expr) => {
+                match op {
+                    UnaryOperator::Negative => {
+                        // TODO: unify expr with integer, catch error, unify
+                        // with float
+                    },
+
+                    UnaryOperator::Not => {
+                        // TODO: unify exper with boolean, integer
+                    },
+                }
+
+                self.check_expression(expr)
+            },
+
+            ExpressionKind::FnCall(ref func, ref args) => {
+                let fn_type_id = self.check_expression(func);
+
+                // make sure that `func` is a function
+                let general_fn_type = Type::Function(
+                    self.ty_env.add_new_type_variable(),
+                    self.ty_env.add_new_type_variable(),
+                );
+                let general_fn_ty_id = self.ty_env.get_or_add_type(general_fn_type);
+
+                self.try_unify(fn_type_id, general_fn_ty_id, func.span);
+
+                match self.ty_env.get_type(fn_type_id) {
+                    Type::Function(fn_args_type_id, ret_type_id) => {
+                        let fn_args_type_id = *fn_args_type_id;
+                        let ret_type_id = *ret_type_id;
+
+                        // now assert that the arguments should be a tuple
+                        let tuple_type_id = {
+                            let mut tuple_args = Vec::with_capacity(args.len());
+
+                            for arg in args {
+                                self.check_expression(arg);
+                                tuple_args.push(arg.type_id);
+                            }
+
+                            self.ty_env.get_or_add_type(Type::Tuple(tuple_args))
+                        };
+
+                        let mut args_span = if args.is_empty() {
+                            Span::empty()
+                        } else {
+                            let mut res = args[0].span;
+                            res.grow_to_contain(&args.last().unwrap().span);
+                            res
+                        };
+
+                        self.try_unify(tuple_type_id, fn_args_type_id, args_span);
+                        ret_type_id
+                    },
+
+                    // unreachable due to unification
+                    _ => unreachable!(),
+                }
+            },
+
+            ExpressionKind::Literal(ref literal) => match literal {
+                LiteralKind::Integer(_) => self.ty_env.get_or_add_type(Type::Integer),
+                LiteralKind::String(_) => self.ty_env.get_or_add_type(Type::String),
+                LiteralKind::Float(_) => self.ty_env.get_or_add_type(Type::Float),
+                LiteralKind::Boolean(_) => self.ty_env.get_or_add_type(Type::Boolean),
+            },
+
+            ExpressionKind::Identifier(ref ident) => self.ty_env.get_type_id_for_ident(ident),
+        };
+
+        self.try_unify(expr.type_id, res, expr.span);
+        res
+    }
+}
+
+pub(super) fn typecheck<'src>(
+    script: Script,
+    ty_env: TypeEnvironment<'src>,
+    source: &'src str,
+) -> (Script, TypeEnvironment<'src>) {
+    let typechecker = Typecheck::new(ty_env, source);
+    typechecker.check_script(script)
+}

--- a/laria_backend/src/hir/types.rs
+++ b/laria_backend/src/hir/types.rs
@@ -1,0 +1,189 @@
+use std::collections::HashMap;
+
+use crate::errors::{DiagnosticsContext, Span};
+
+pub(super) type TypeId = usize;
+
+#[derive(Clone, Debug, PartialEq)]
+pub(super) enum Type {
+    Variable(u64),
+    Integer,
+    Boolean,
+    Float,
+    String,
+    Function(TypeId, TypeId),
+    Tuple(Vec<TypeId>),
+}
+
+impl Type {
+    /// Convenience function to create the unit type.
+    pub(super) const fn unit() -> Self {
+        Self::Tuple(Vec::new())
+    }
+
+    /// Returns a string, suitable for display, that represents this type.
+    /// This isn't a [`Display`] or [`ToString`] implementation since this
+    /// requires access to a [`TypeEnvironment`].
+    ///
+    /// [`Display`]: std::fmt::Display
+    fn to_string(&self, ty_env: &TypeEnvironment) -> String {
+        match self {
+            Type::Variable(id) => format!("{{type variable #{}}}", id),
+            Type::Integer => "{integer}".to_owned(),
+            Type::Boolean => "bool".to_owned(),
+            Type::Float => "{float}".to_owned(),
+            Type::String => "string".to_owned(),
+
+            Type::Function(args_id, return_id) => {
+                let args_ty = ty_env.get_type(*args_id).to_string(ty_env);
+                let ret_ty = ty_env.get_type(*return_id).to_string(ty_env);
+                format!("{} -> {}", args_ty, ret_ty)
+            },
+
+            Type::Tuple(contents) => {
+                let contents_string = contents
+                    .into_iter()
+                    .map(|id| ty_env.get_type(*id).to_string(ty_env))
+                    .intersperse(", ".to_owned())
+                    .collect::<String>();
+
+                format!("({})", contents_string)
+            },
+        }
+    }
+}
+
+/// Holds information on the type universe.
+pub(super) struct TypeEnvironment<'src> {
+    type_id_to_type: Vec<Type>,
+    // Let's assume name resolution was done already,
+    // so we don't have any invalid identifiers
+    // TODO: not likely; consider switching to something
+    // like Rust's `DefId`, which is more or less an
+    // interned path to the ident
+    ident_to_type_id: HashMap<String, TypeId>,
+    next_type_var_id: u64,
+    error_ctx: DiagnosticsContext<'src>,
+}
+
+impl<'src> TypeEnvironment<'src> {
+    pub(super) fn new(source: &'src str) -> Self {
+        Self {
+            type_id_to_type: Vec::new(),
+            ident_to_type_id: HashMap::new(),
+            next_type_var_id: 0,
+            error_ctx: DiagnosticsContext::new(source, None),
+        }
+    }
+
+    /// Gets the given type or adds to the universe if it doesn't exist.
+    /// Returns the type's [`TypeId`].
+    pub(super) fn get_or_add_type(&mut self, ty: Type) -> TypeId {
+        // TODO: might be slow
+        for i in 0..self.type_id_to_type.len() {
+            if self.type_id_to_type[i] == ty {
+                return i;
+            }
+        }
+
+        self.type_id_to_type.push(ty);
+        self.type_id_to_type.len() - 1
+    }
+
+    /// Adds a new type variable to the universe with a unique variable id.
+    /// Returns the variable's [`TypeId`] (not its variable id).
+    pub(super) fn add_new_type_variable(&mut self) -> TypeId {
+        let ty = Type::Variable(self.next_type_var_id);
+        self.next_type_var_id += 1;
+        self.get_or_add_type(ty)
+    }
+
+    /// Given a type id, get the concrete type from this environment.
+    pub(super) fn get_type(&self, id: TypeId) -> &Type {
+        &self.type_id_to_type[id]
+    }
+
+    /// Given an identifier, get the associated [`TypeId`].
+    pub(super) fn get_type_id_for_ident(&mut self, ident: &String) -> TypeId {
+        let maybe_res = self.ident_to_type_id.get(ident).copied();
+
+        match maybe_res {
+            Some(res) => res,
+
+            None => {
+                let type_id = self.add_new_type_variable();
+                self.ident_to_type_id.insert(ident.clone(), type_id);
+                type_id
+            },
+        }
+    }
+
+    /// Unify two types, asserting that they must be equal.
+    pub(super) fn unify(
+        &mut self,
+        first_id: TypeId,
+        second_id: TypeId,
+        span: Span,
+    ) -> Result<(), ()> {
+        let first_ty = self.get_type(first_id);
+        let second_ty = self.get_type(second_id);
+        match (first_ty, second_ty) {
+            (Type::Variable(_), _) => {
+                if first_ty != second_ty {
+                    self.type_id_to_type[first_id] = self.get_type(second_id).clone();
+                }
+            },
+
+            (_, Type::Variable(_)) => {
+                self.unify(second_id, first_id, span)?;
+            },
+
+            (Type::Integer, Type::Integer)
+            | (Type::Boolean, Type::Boolean)
+            | (Type::Float, Type::Float)
+            | (Type::String, Type::String) => {},
+
+            (Type::Function(params_id_1, ret_id_1), Type::Function(params_id_2, ret_id_2)) => {
+                // These variables are needed to copy the type ids.
+                // Otherwise, the borrow checker complains when `unify`
+                // tries to take a mutable reference to `self`.
+                let params_id_1 = *params_id_1;
+                let params_id_2 = *params_id_2;
+                let ret_id_1 = *ret_id_1;
+                let ret_id_2 = *ret_id_2;
+
+                self.unify(params_id_1, params_id_2, span)?;
+                self.unify(ret_id_1, ret_id_2, span)?;
+            },
+
+            (Type::Tuple(type_ids_1), Type::Tuple(type_ids_2)) => {
+                // Sort of a hack: the type ids are iterated over, copied, and zipped together
+                // into tuples. These tuples are then collected into a Vec, which then gets
+                // iterated over. This doesn't seem great, but iterating over the iterator
+                // produced by `zip` produced a borrow checker error.
+                let type_ids_2_iter = type_ids_2.iter().copied();
+                let type_ids: Vec<_> = type_ids_1.iter().copied().zip(type_ids_2_iter).collect();
+
+                for (left_id, right_id) in type_ids {
+                    self.unify(left_id, right_id, span)?;
+                }
+            },
+
+            (_, _) => {
+                self.error_ctx
+                    .build_error(format!(
+                        "expected {}, got {}",
+                        second_ty.to_string(self),
+                        first_ty.to_string(self)
+                    ))
+                    .span_label(span, "type error detected here")
+                    .note("this may be inaccurate; these diagnostics will improve in the future")
+                    .emit();
+
+                return Err(());
+            },
+        }
+
+        Ok(())
+    }
+}

--- a/laria_backend/src/lib.rs
+++ b/laria_backend/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::comparison_chain)]
 #![allow(clippy::needless_doctest_main)]
 #![allow(unused)]
+#![feature(iter_intersperse)]
 #![feature(or_patterns)]
 #![feature(peekable_next_if)]
 // Got turned off by allow(unused)
@@ -8,6 +9,7 @@
 #![warn(unused_must_use)]
 
 mod errors;
+mod hir;
 mod lexer;
 mod lower;
 mod parser;
@@ -24,8 +26,9 @@ use std::{
 pub use lower::lower_to_vm;
 use parser::ast;
 
-/// Lexes and parses a file. Aborts on errors (this may be temporary).
-pub fn lex_and_parse(filename: impl AsRef<Path>) -> ast::Script {
+/// Parses a script, validates it, and lowers it for use with the VM.
+/// This currently aborts on errors, but this will change in the future.
+pub fn compile_for_vm(filename: impl AsRef<Path>) -> laria_vm::Script {
     let filename = filename.as_ref();
     let mut file = match File::open(filename) {
         Ok(res) => BufReader::new(res),
@@ -59,8 +62,14 @@ pub fn lex_and_parse(filename: impl AsRef<Path>) -> ast::Script {
         },
     };
 
-    match parser::parse(tokens, &source) {
+    let ast = match parser::parse(tokens, &source) {
         Ok(res) => res,
         Err(_) => exit(2),
-    }
+    };
+
+    // TODO: consume the AST once `lower_to_vm`
+    // is modified to consume IR
+    hir::validate(ast.clone(), &source);
+
+    lower_to_vm::lower_script(ast)
 }

--- a/laria_backend/src/lib.rs
+++ b/laria_backend/src/lib.rs
@@ -25,10 +25,11 @@ use std::{
 
 pub use lower::lower_to_vm;
 use parser::ast;
+use unstable_features::compiler::UnstableFeatures;
 
 /// Parses a script, validates it, and lowers it for use with the VM.
 /// This currently aborts on errors, but this will change in the future.
-pub fn compile_for_vm(filename: impl AsRef<Path>) -> laria_vm::Script {
+pub fn compile_for_vm(filename: impl AsRef<Path>, features: UnstableFeatures) -> laria_vm::Script {
     let filename = filename.as_ref();
     let mut file = match File::open(filename) {
         Ok(res) => BufReader::new(res),
@@ -67,9 +68,11 @@ pub fn compile_for_vm(filename: impl AsRef<Path>) -> laria_vm::Script {
         Err(_) => exit(2),
     };
 
-    // TODO: consume the AST once `lower_to_vm`
-    // is modified to consume IR
-    hir::validate(ast.clone(), &source);
+    if features.typecheck {
+        // TODO: consume the AST once `lower_to_vm`
+        // is modified to consume IR
+        hir::validate(ast.clone(), &source);
+    }
 
     lower_to_vm::lower_script(ast)
 }

--- a/laria_backend/src/parser/ast.rs
+++ b/laria_backend/src/parser/ast.rs
@@ -39,14 +39,21 @@ impl fmt::Display for Script {
 pub struct FunctionDecl {
     pub name: String,
     pub arguments: Vec<(String, String)>,
+    pub return_type: Option<String>,
     pub span: Span,
 }
 
 impl FunctionDecl {
-    pub fn new(name: String, arguments: Vec<(String, String)>, span: Span) -> Self {
+    pub fn new(
+        name: String,
+        arguments: Vec<(String, String)>,
+        return_type: Option<String>,
+        span: Span,
+    ) -> Self {
         Self {
             name,
             arguments,
+            return_type,
             span,
         }
     }

--- a/laria_backend/src/parser/mod.rs
+++ b/laria_backend/src/parser/mod.rs
@@ -249,7 +249,8 @@ impl<'src> Parser<'src> {
             return Err(ParseError::TooManyArgsOnFnDef);
         }
 
-        Ok(FunctionDecl::new(fn_name, args, header_span))
+        // TODO: parse return type
+        Ok(FunctionDecl::new(fn_name, args, None, header_span))
     }
 
     fn parse_extern_fn(&mut self) -> Result<ExternFn, ParseError> {

--- a/laria_backend/src/unstable_features/compiler.rs
+++ b/laria_backend/src/unstable_features/compiler.rs
@@ -20,7 +20,7 @@ pub enum UnstableFeaturesError {
 // nb. bool::default returns false
 #[derive(Clone, Copy, Debug, Default)]
 pub struct UnstableFeatures {
-    typecheck: bool,
+    pub typecheck: bool,
 }
 
 impl UnstableFeatures {


### PR DESCRIPTION
This is currently available behind the `-U typecheck` feature flag since the type checker can easily be confused by introducing multiple items with the same identifier. This will be fixed when paths are introduced. Regardless, it's still helpful to have this available on main so I can test it without switching branches.

Despite its flaws, the type checker already found a bug in [examples/test.lri]: `main`'s signature (implicitly) shows that it returns `()`, but in reality it returns `{integer}`. In addition, it correctly pointed out that it inferred `print` to have type `(String) -> ()` from its first use, but then it saw `print` called with an integer argument. That probably means I've at least done something right! :)

bors r+

[examples/test.lri]: https://github.com/PatchMixolydic/laria/blob/bc937ccff449cb7936d575f1d2f5b426db7853e0/examples/test.lri